### PR TITLE
additional option for isotonic regression algorithm, and optimizations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,3 +31,5 @@ Imports:
     tibble,
     vctrs,
     bde
+Suggests:
+    monotone

--- a/R/coercion.R
+++ b/R/coercion.R
@@ -224,7 +224,11 @@ reldiag_numeric <- function(x,
   }
 
   ###
-  CEP_pav <- monotone::monotone(y)
+  CEP_pav <- if (requireNamespace("monotone", quietly = TRUE)) {
+    monotone::monotone(y)
+  } else {
+    stats::isoreg(y)$yf
+  }
   bins <- rle(CEP_pav)
   red_iKnots <- cumsum(bins$lengths)
   df_pav <- tibble::tibble(

--- a/R/coercion.R
+++ b/R/coercion.R
@@ -188,6 +188,10 @@ reldiag_numeric <- function(x,
   stopifnot(identical(length(x), length(y)))
   stopifnot(isTRUE(all(x >= 0 & x <= 1)))
 
+  ord <- order(x, -y)
+  x <- x[ord]
+  y <- y[ord]
+
   if (is.null(xtype) && is.null(xvalues)) {
     xtype <- detect_xtype(x)
   } else if (!is.null(xvalues)) {
@@ -220,27 +224,22 @@ reldiag_numeric <- function(x,
   }
 
   ###
-  pav_result <- stats::isoreg(x, y)
-  red_iKnots <- with(
-    pav_result,
-    which(!duplicated(yf[iKnots], fromLast = TRUE)) %>% iKnots[.]
-  )
-  df_pav <- with(
-    pav_result,
-    tibble::tibble(
-      case_id = if (isOrd) seq_len(length(y)) else ord,
-      x = if (isOrd) x else x[ord],
-      y = if (isOrd) y else y[ord],
-      bin_id = rep.int(seq_along(red_iKnots), times = diff(c(0, red_iKnots))),
-      CEP_pav = yf
-    )
+  CEP_pav <- monotone::monotone(y)
+  bins <- rle(CEP_pav)
+  red_iKnots <- cumsum(bins$lengths)
+  df_pav <- tibble::tibble(
+    case_id = ord,
+    x = x,
+    y = y,
+    bin_id = rep.int(seq_along(red_iKnots), times = bins$lengths),
+    CEP_pav = CEP_pav
   )
   df_bins <- tibble::tibble(
     bin_id = seq_along(red_iKnots),
-    n = diff(c(0, red_iKnots)),
-    x_min = df_pav$x[c(0, utils::head(red_iKnots,-1)) + 1],
-    x_max = df_pav$x[red_iKnots],
-    CEP_pav = df_pav$CEP_pav[red_iKnots]
+    n = bins$lengths,
+    x_min = x[c(0, utils::head(red_iKnots,-1)) + 1],
+    x_max = x[red_iKnots],
+    CEP_pav = bins$values
   )
 
   regions <- if (!do_region) {


### PR DESCRIPTION
This PR allows users who have the `monotone` package installed to use their implementation of the isotonic regression algorithm.

The speedup can be fairly substantial, particularly when there are many forecast cases with few unique forecast values. At some point, the transition to an implementation that solves the weighted least squares problem should be completed.

The `resampling()` function has been rewritten with the result of some performance gains and a (subjectively) better structure.